### PR TITLE
fix tcp server bug

### DIFF
--- a/COMTool/conn/conn_tcp_udp.py
+++ b/COMTool/conn/conn_tcp_udp.py
@@ -275,9 +275,11 @@ class TCP_UDP(COMM):
         while 1:
             try:
                 port = int(text)
+                self.config['port'] = port
                 break
             except Exception:
                 text = text[:-1]
+                break
         self.porttEdit.setText(text)
 
     def onSerialConfigChanged(self, conf_type, obj, value_type, caller=""):


### PR DESCRIPTION
1、解决Server端口修改不生效的问题；缺失端口修改赋值
2、解决Server端口输入框删除最后一个字符时死循环，导致程序无响应；缺少 break