### PR TITLE
fix appear too small on high-resolution screens

### DIFF
--- a/COMTool/main2.py
+++ b/COMTool/main2.py
@@ -758,6 +758,7 @@ def main():
     '''
     ret = 1
     try:
+        QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
         app = QApplication(sys.argv)
         splash = Splash(app)
         eventFilter = EventFilter()

--- a/COMTool/main2.py
+++ b/COMTool/main2.py
@@ -43,7 +43,7 @@ except ImportError:
     from COMTool.pluginItems import PluginItem
     from .widgets import TitleBar, CustomTitleBarWindowMixin, EventFilter, ButtonCombbox, HelpWidget
 
-from PyQt5.QtCore import pyqtSignal, Qt, QRect, QMargins
+from PyQt5.QtCore import pyqtSignal, Qt, QRect, QMargins, ,QCoreApplication
 from PyQt5.QtWidgets import (QApplication, QWidget,QPushButton,QMessageBox,QDesktopWidget,QMainWindow,
                              QVBoxLayout,QHBoxLayout,QGridLayout,QTextEdit,QLabel,QRadioButton,QCheckBox,
                              QLineEdit,QGroupBox,QSplitter,QFileDialog, QScrollArea, QTabWidget, QMenu, QSplashScreen)


### PR DESCRIPTION
fix appear too small on high-resolution screens, enable HighDpiScaling

high-resolution screen adaptation OFF:
![屏幕截图 2023-12-15 152418](https://github.com/Neutree/COMTool/assets/44724797/a9137aef-5a31-49ec-80f9-9abaf7f25d69)


high-resolution screen adaptation ON:
![屏幕截图 2023-12-15 152328](https://github.com/Neutree/COMTool/assets/44724797/bd45734d-997e-4e71-a278-200d6e91ccc5)
