### PR TITLE
优化了下ci（主要是macOS方面）

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        os: ["windows-latest", "macos-latest", "macos-11"]
+        os: ["windows-latest", "macos-latest", "macos-13"]
         python-version: ["3.8", "3.9", "3.10"] # must use str, not int, or 3.10 will be recognized as 3.1
     runs-on: ${{ matrix.os }}
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"] # must use str, not int, or 3.10 will be recognized as 3.1
-        os: ["macos-latest", "macos-11"]
+        os: ["macos-latest", "macos-13"]
     runs-on: ${{ matrix.os }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    name: test pack task
+    name: release and upload assets task
     # The type of runner that the job will run on
     strategy:
       matrix:

--- a/pack.py
+++ b/pack.py
@@ -159,10 +159,13 @@ if __name__ == "__main__":
                 windows_out = windows_out_new
             print(windows_out)
         elif os_name.startswith("macos"):
-            if os_name != "macos-latest":
-                macos_out_new = macos_out.replace("macos", os_name.replace("-", "_"))
-                os.rename(macos_out, macos_out_new)
-                macos_out = macos_out_new
+            macos_version = os_name.split("-")[1]
+            if macos_version.isdigit() and int(macos_version) <= 14:
+                macos_out_new = macos_out.replace("macos", "macos_x64")
+            else:   # github actions macos-latest is using M1 chip
+                macos_out_new = macos_out.replace("macos", "macos_arm64")
+            os.rename(macos_out, macos_out_new)
+            macos_out = macos_out_new
             print(macos_out)
         else:
             sys.exit(1)

--- a/pack.py
+++ b/pack.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
             print(windows_out)
         elif os_name.startswith("macos"):
             macos_version = os_name.split("-")[1]
-            if macos_version.isdigit() and int(macos_version) <= 14:
+            if macos_version.isdigit() and int(macos_version) < 14:
                 macos_out_new = macos_out.replace("macos", "macos_x64")
             else:   # github actions macos-latest is using M1 chip
                 macos_out_new = macos_out.replace("macos", "macos_arm64")


### PR DESCRIPTION
* 修了下跑不过ci的macOS版本，太低了似乎被GitHub撤了。
* 最新的应该是用m1的机子，所以我改成用x64和arm64区分了，避免某些用intel的直接下最新的发现跑不了和用apple silicon的下错靠转译跑降效率

ref: https://docs.github.com/zh/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#%E7%94%A8%E4%BA%8E%E5%85%AC%E5%85%B1%E5%AD%98%E5%82%A8%E5%BA%93%E7%9A%84-github-%E6%89%98%E7%AE%A1%E7%9A%84%E6%A0%87%E5%87%86%E8%BF%90%E8%A1%8C%E5%99%A8