### PR TITLE
fix  send setting CRLF

### DIFF
--- a/COMTool/plugins/base.py
+++ b/COMTool/plugins/base.py
@@ -186,7 +186,10 @@ class Plugin_Base(QObject):
         if not data:
             return b''
         if usrCRLF:
-            data = data.replace("\n", "\r\n")
+            if data.endswith("\n"):
+                data = data.replace("\n", "\r\n")
+            else:
+                data = data + "\r\n"
         if isHexStr:
             if usrCRLF:
                 data = data.replace("\r\n", " ")


### PR DESCRIPTION

修复发送选项只勾选CRLF，且发送输入不带"\n" 时发送内容不会追加"\r\n"  

单独勾选CRLF在UI中是被允许的，但没有任何提示说明在发送内容中需要包含"\n" 此选项才能生效