### PR TITLE
修复TCP/UDP切换时控件逻辑问题以及历史发送内容超长不渲染的问题

### DIFF
--- a/COMTool/Combobox.py
+++ b/COMTool/Combobox.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QComboBox,QListView
+from PyQt5.QtWidgets import QComboBox,QListView,QApplication
 from PyQt5.QtCore import pyqtSignal
 
 
@@ -21,6 +21,14 @@ class ComboBox(QComboBox):
         pass
 
     def _showPopup(self):
+        max_w = 0
+        for i in range(self.count()):
+            w = self.view().sizeHintForColumn(i)
+            if w > max_w:
+                max_w = w
+
+        screen_width = QApplication.desktop().availableGeometry().width()
+        self.view().setMinimumWidth(min(max_w + 50, screen_width))
         super(ComboBox, self).showPopup()
     
     def showItems(self):

--- a/COMTool/Combobox.py
+++ b/COMTool/Combobox.py
@@ -21,12 +21,6 @@ class ComboBox(QComboBox):
         pass
 
     def _showPopup(self):
-        max_w = 0
-        for i in range(self.count()):
-            w = self.view().sizeHintForColumn(i)
-            if w > max_w:
-                max_w = w
-        self.view().setMinimumWidth(max_w + 50)
         super(ComboBox, self).showPopup()
     
     def showItems(self):

--- a/COMTool/conn/conn_tcp_udp.py
+++ b/COMTool/conn/conn_tcp_udp.py
@@ -174,8 +174,8 @@ class TCP_UDP(COMM):
         self.updateClientsSignal.connect(self.updateClients)
         self.protoclTcpRadioBtn.clicked.connect(lambda: self.changeProtocol("tcp"))
         self.protoclUdpRadioBtn.clicked.connect(lambda: self.changeProtocol("udp"))
-        self.modeServerRadioBtn.clicked.connect(lambda: self.changeMode("server"))
-        self.modeClientRadioBtn.clicked.connect(lambda: self.changeMode("client"))
+        self.modeServerRadioBtn.clicked.connect(lambda: self.changeMode("server", self.config["protocol"]))
+        self.modeClientRadioBtn.clicked.connect(lambda: self.changeMode("client", self.config["protocol"]))
         self.clientsCombobox.currentIndexChanged.connect(self.serverModeClientChanged)
         self.disconnetClientBtn.clicked.connect(self.serverModeDisconnectClient)
         self.autoReconnect.stateChanged.connect(lambda x: self.setVar("auto_reconnect", value = x))
@@ -190,46 +190,46 @@ class TCP_UDP(COMM):
                 self.modeClientRadioBtn.show()
                 self.modeServerRadioBtn.show()
                 self.modeLabel.show()
-                self.changeMode(self.config["mode"], init=True)
+                self.changeMode(self.config["mode"], protocol, init=True)
             else:
-                self.targetCombobox.show()
-                self.targetLabel.show()
-                self.selfIPandPortLabel.show()
-                self.selfIPandPort.show()
-                self.porttEdit.show()
-                self.portLabel.show()
-                self.clientsCombobox.hide()
-                self.disconnetClientBtn.hide()
-                self.autoReconnect.hide()
-                self.autoReconnectIntervalEdit.hide()
-                self.autoReconnetLable.hide()
-                self.modeClientRadioBtn.hide()
-                self.modeServerRadioBtn.hide()
-                self.modeLabel.hide()
-                self.widget.adjustSize()
+                self.modeClientRadioBtn.show()
+                self.modeServerRadioBtn.show()
+                self.modeLabel.show()
+                self.changeMode(self.config["mode"], protocol, init=True)
             self.config["protocol"] = protocol
 
-    def changeMode(self, mode, init=False):
+    def changeMode(self, mode, protocol, init=False):
         if init or mode != self.config["mode"]:
             if self.isConnected():
                 self.openCloseSerial()
             if mode == "server":
+                if protocol == "tcp":
+                    self.clientsCombobox.show()
+                    self.disconnetClientBtn.show()
+                else:
+                    self.clientsCombobox.hide()
+                    self.disconnetClientBtn.hide()
+
                 self.targetCombobox.hide()
                 self.targetLabel.hide()
                 self.selfIPandPortLabel.hide()
                 self.selfIPandPort.hide()
                 self.porttEdit.show()
                 self.portLabel.show()
-                self.clientsCombobox.show()
-                self.disconnetClientBtn.show()
                 self.autoReconnect.hide()
                 self.autoReconnectIntervalEdit.hide()
                 self.autoReconnetLable.hide()
             else:
+                if protocol == "tcp":
+                    self.selfIPandPortLabel.show()
+                    self.selfIPandPort.show()
+                    self.selfIPandPort.setReadOnly(True)
+                else:
+                    self.selfIPandPortLabel.hide()
+                    self.selfIPandPort.hide()
+
                 self.targetCombobox.show()
                 self.targetLabel.show()
-                self.selfIPandPortLabel.show()
-                self.selfIPandPort.show()
                 self.porttEdit.hide()
                 self.portLabel.hide()
                 self.clientsCombobox.hide()
@@ -308,11 +308,11 @@ class TCP_UDP(COMM):
         elif conf_type == "mode":
             if value == "client":
                 obj.setChecked(True)
-                self.changeMode("client", init=True)
+                self.changeMode("client", self.config["protocol"], init=True)
             else:
                 obj.setChecked(False)
                 self.modeServerRadioBtn.setChecked(True)
-                self.changeMode("server", init=True)
+                self.changeMode("server", self.config["protocol"], init=True)
         elif conf_type == "target":
             for i, target in enumerate(self.config["target"][1]):
                 self.targetCombobox.addItem(target)


### PR DESCRIPTION
问题一、如图在点击TCP/UDP 以及 Client/Server 时，相对应的空间展示、隐藏的联动时混乱的。

![iShot_2025-08-01_10 09 19](https://github.com/user-attachments/assets/7b61b57b-f73f-4d10-aa03-7cf424615459)
![iShot_2025-08-01_10 18 34](https://github.com/user-attachments/assets/3ae05cac-71f0-4555-8b8e-b5eefa8c5063)

问题二、历史发送的内容单行超长时，根据内容的宽度计算控件宽度方法是有问题的，导致无法渲染出内容。
