### PR TITLE
Fix slow performance on second and subsequent application startups

### DIFF
--- a/COMTool/parameters.py
+++ b/COMTool/parameters.py
@@ -42,6 +42,10 @@ configFilePath=configFileName
 if sys.platform.startswith('linux') or sys.platform.startswith('darwin') or sys.platform.startswith('freebsd'):
     configFileDir = os.path.join(os.getenv("HOME"), ".config/comtool")
     configFilePath = get_config_path(configFileName)
+elif sys.platform.startswith("win"):
+    appdata = os.getenv("APPDATA") or os.path.expanduser("~\\AppData\\Roaming")
+    configFileDir = os.path.join(appdata, appName)
+    configFilePath = get_config_path(configFileName)
 else:
     configFileDir = os.path.abspath(os.getcwd())
     configFilePath  = os.path.join(configFileDir, configFileName)


### PR DESCRIPTION
软件针对Windows 将 config.json 和 run.log 放到当前工作目录。这会触发如下问题https://github.com/Neutree/COMTool/issues/192 ，导致二次启动显著变慢，我修改了软件的配置以及日志保存到AppData目录下，这也是Windows所推荐的，后续未再遇见此问题

1. 目录不可写或受控时的权限/虚拟化（Program Files/UAC）；
2. 杀软/Defender 对可执行目录下频繁写入文件的深度扫描；
3. 关闭时写入→立即再次启动时，上一轮写入文件的扫描/锁释放叠加，
